### PR TITLE
Lock down a few more

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ For more details, please refer zaru:
 1. no padding support
 2. replace "/" with "$" instead of ""
 
+## Other implementations
+
+* [zaru](https://github.com/madrobby/zaru) (Ruby)
+* [sanitize](https://github.com/ksze/sanitize) (Python)
+* [owasp-java-fileio](https://github.com/augustd/owasp-java-fileio) (Java)
+* [node-sanitize-filename](https://github.com/augustd/owasp-java-fileio) (JavaScript)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more details, please refer zaru:
 * [zaru](https://github.com/madrobby/zaru) (Ruby)
 * [sanitize](https://github.com/ksze/sanitize) (Python)
 * [owasp-java-fileio](https://github.com/augustd/owasp-java-fileio) (Java)
-* [node-sanitize-filename](https://github.com/augustd/owasp-java-fileio) (JavaScript)
+* [node-sanitize-filename](https://github.com/parshap/node-sanitize-filename) (JavaScript)
 
 ## License
 

--- a/src/sanitize_filename/core.clj
+++ b/src/sanitize_filename/core.clj
@@ -7,9 +7,7 @@
 (def CHARACTER_FILTER #"[\x00-\x1F\x80-\x9f\/\\:\*\?\"<>\|]")
 (def INVALID_TRAILING_CHARS #"[\. ]+$")
 (def UNICODE_WHITESPACE #"\p{Space}")
-(def WINDOWS_RESERVED_NAMES #{"CON" "PRN" "AUX" "NUL" "COM1" "COM2" "COM3" "COM4" "COM5"
-                              "COM6" "COM7" "COM8" "COM9" "LPT1" "LPT2" "LPT3" "LPT4"
-                              "LPT5" "LPT6" "LPT7" "LPT8" "LPT9"})
+(def WINDOWS_RESERVED_NAMES #"^(?i)(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$")
 (def FALLBACK_FILENAME "file")
 
 (defn- normalize [filename]
@@ -18,7 +16,7 @@
       (s/replace UNICODE_WHITESPACE "")))
 
 (defn- filter-windows-reserved-names [filename]
-  (if (WINDOWS_RESERVED_NAMES (s/upper-case filename))
+  (if (re-matches WINDOWS_RESERVED_NAMES filename)
     FALLBACK_FILENAME
     filename
     )

--- a/test/sanitize_filename/core_test.clj
+++ b/test/sanitize_filename/core_test.clj
@@ -56,11 +56,10 @@
            (sut/sanitize "a\u001fb")))
     (is (= "file"
            (sut/sanitize "\u001f"))) ; due to str/trim
-    ;; (is (= "$" ; https://en.wikipedia.org/wiki/C0_and_C1_control_codes
-    ;;        (sut/sanitize "\u0080")))
-    ;; (is (= "$"
-    ;;        (sut/sanitize "\u009f")))
-    )
+    (is (= "$" ; https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+           (sut/sanitize "\u0080")))
+    (is (= "$"
+           (sut/sanitize "\u009f"))))
 
   (testing "replaces whitespace"
     (is (= "ab"
@@ -81,16 +80,16 @@
            (sut/sanitize "\ta\n"))))
 
   (testing "extends reserved Unix names with default"
-    (is (= "file."
+    (is (= "file$"
            (sut/sanitize ".")))
-    (is (= "file.."
+    (is (= "file$$"
            (sut/sanitize ".."))))
 
   (testing "handles invalid trailing chars for Windows"
-    ;; (is (= "name" ; https://msdn.microsoft.com/en-us/library/aa365247(v=vs.85).aspx#naming_conventions
-    ;;        (sut/sanitize "name.")))
-    ;; (is (= "name"
-    ;;        (sut/sanitize "name..")))
+    (is (= "name$"
+           (sut/sanitize "name.")))
+    (is (= "name$$"
+           (sut/sanitize "name..")))
     (is (= "name"
            (sut/sanitize "name "))))
 

--- a/test/sanitize_filename/core_test.clj
+++ b/test/sanitize_filename/core_test.clj
@@ -17,9 +17,10 @@
            (sut/sanitize "AUX")))
     (is (= "file"
            (sut/sanitize "NUL")))
-    ;; (is (= "file" ; https://msdn.microsoft.com/en-us/library/aa365247(v=vs.85).aspx#naming_conventions
-    ;;        (sut/sanitize "NUL.txt")))
-    )
+    (is (= "file"
+           (sut/sanitize "NUL.txt")))
+    (is (= "file"
+           (sut/sanitize "NUL."))))
 
   (testing "replaces invalid characters"
     (is (= "$"


### PR DESCRIPTION
Hey, I'm adding two more pull requests, one with more lock downs, one with more lenient behaviour. 

My intention is to show where I'd like to take this. If you feel comfortable with the direction, please consider allowing contributions/co-maintainership. As I mentioned earlier, I'd like to keep this under one package, if our intentions align.

This PR:
- Don't allow file extensions on special windows names (as per https://msdn.microsoft.com/en-us/library/aa365247(v=vs.85).aspx#naming_conventions)
- Disallow file names ending with space and dots (same source as above)
- Replace C1 control characters (similar to https://github.com/parshap/node-sanitize-filename/blob/master/index.js)
