### PR TITLE
More lenient behaviour 

### DIFF
--- a/src/sanitize_filename/core.clj
+++ b/src/sanitize_filename/core.clj
@@ -9,11 +9,6 @@
 (def RESERVED_NAMES #"^\.+$")
 (def FALLBACK_FILENAME "file")
 
-(defn- normalize [filename]
-  (-> filename
-      s/trim
-      (s/replace UNICODE_WHITESPACE "")))
-
 (defn- filter-windows-reserved-names [filename]
   (if (WINDOWS_RESERVED_NAMES (s/upper-case filename))
     "file"
@@ -60,12 +55,11 @@
 ;; exported function
 (defn sanitize [filename]
   (-> filename
-      normalize
       -sanitize
       -filter
       truncate)
   )
 
 ;(defn -main []
-;  should print "ab我是c.zip"
+;  should print "$a$b$  我是c.zip"
 ;  (println (sanitize "/a/b/  我是c.zip")))

--- a/src/sanitize_filename/core.clj
+++ b/src/sanitize_filename/core.clj
@@ -6,6 +6,7 @@
 (def WINDOWS_RESERVED_NAMES #{"CON" "PRN" "AUX" "NUL" "COM1" "COM2" "COM3" "COM4" "COM5"
                               "COM6" "COM7" "COM8" "COM9" "LPT1" "LPT2" "LPT3" "LPT4"
                               "LPT5" "LPT6" "LPT7" "LPT8" "LPT9"})
+(def RESERVED_NAMES #"^\.+$")
 (def FALLBACK_FILENAME "file")
 
 (defn- normalize [filename]
@@ -27,9 +28,9 @@
     )
   )
 
-(defn- filter-dot [filename]
-  (if (.startsWith filename ".")
-    (str FALLBACK_FILENAME filename)
+(defn- filter-reserved-names [filename]
+  (if (re-matches RESERVED_NAMES filename)
+    FALLBACK_FILENAME
     filename
     )
   )
@@ -37,8 +38,9 @@
 (defn- -filter [filename]
   (-> filename
       filter-windows-reserved-names
+      filter-reserved-names
       filter-blank
-      filter-dot)
+      )
   )
 
 (defn- -sanitize [filename]

--- a/test/sanitize_filename/core_test.clj
+++ b/test/sanitize_filename/core_test.clj
@@ -54,8 +54,8 @@
            (sut/sanitize "a\u001cb")))
     (is (= "a$b"
            (sut/sanitize "a\u001fb")))
-    (is (= "file"
-           (sut/sanitize "\u001f"))) ; due to str/trim
+    (is (= "$"
+           (sut/sanitize "\u001f")))
     ;; (is (= "$" ; https://en.wikipedia.org/wiki/C0_and_C1_control_codes
     ;;        (sut/sanitize "\u0080")))
     ;; (is (= "$"
@@ -63,21 +63,17 @@
     )
 
   (testing "replaces whitespace"
-    (is (= "ab"
-           (sut/sanitize "a b")))
-    (is (= "ab"
+    (is (= "a$b"
            (sut/sanitize "a\tb")))
-    (is (= "ab"
+    (is (= "a$b"
            (sut/sanitize "a\nb")))
-    (is (= "ab"
+    (is (= "a$b"
            (sut/sanitize "a\fb")))
-    (is (= "ab"
+    (is (= "a$b"
            (sut/sanitize "a\rb")))
-    (is (= "ab"
+    (is (= "a$b"
            (sut/sanitize "a\u000bb")))
-    (is (= "a"
-           (sut/sanitize " a ")))
-    (is (= "a"
+    (is (= "$a$"
            (sut/sanitize "\ta\n"))))
 
   (testing "extends reserved Unix names with default"
@@ -91,8 +87,9 @@
     ;;        (sut/sanitize "name.")))
     ;; (is (= "name"
     ;;        (sut/sanitize "name..")))
-    (is (= "name"
-           (sut/sanitize "name "))))
+    ;; (is (= "name$"
+    ;;        (sut/sanitize "name ")))
+    )
 
   (testing "trims long names"
     (let [name-with-n-chars (fn [n] (str/join "" (take n (repeat "x"))))]
@@ -119,4 +116,6 @@
     (is (= "LPT10"
            (sut/sanitize "LPT10")))
     (is (= "笊,ざる.pdf"
-           (sut/sanitize "笊,ざる.pdf")))))
+           (sut/sanitize "笊,ざる.pdf")))
+    (is (= " a with spaces"
+           (sut/sanitize " a with spaces")))))

--- a/test/sanitize_filename/core_test.clj
+++ b/test/sanitize_filename/core_test.clj
@@ -40,7 +40,7 @@
            (sut/sanitize "|")))
     (is (= "$"
            (sut/sanitize "\"")))
-    (is (= "file..$file$$.$$"
+    (is (= "..$file$$.$$"
            (sut/sanitize "../file/>.*\"")))
     (is (= "$.pdf"
            (sut/sanitize "<.pdf"))))
@@ -81,9 +81,9 @@
            (sut/sanitize "\ta\n"))))
 
   (testing "extends reserved Unix names with default"
-    (is (= "file."
+    (is (= "file"
            (sut/sanitize ".")))
-    (is (= "file.."
+    (is (= "file"
            (sut/sanitize ".."))))
 
   (testing "handles invalid trailing chars for Windows"
@@ -112,8 +112,8 @@
   (testing "keeps valid names"
     (is (= "valid.mp3"
            (sut/sanitize "valid.mp3")))
-    ;; (is (= ".valid"
-    ;;        (sut/sanitize ".valid")))
+    (is (= ".valid"
+           (sut/sanitize ".valid")))
     (is (= "valid"
            (sut/sanitize "valid")))
     (is (= "LPT10"


### PR DESCRIPTION
This is the PR invers to #3 for discussion. This is not based on top of #3, so this is not meant for merging. I have a separate branch for that.
- Allow leading dots and whitespace in names (including leading).

Now, as I understand from #1, your concerns evolve around good, accessible names. My intention on the contrary is to limit illegal names only and provide a way to securely have the user provide file names (without locking down valid names).

If you are interested, I would be happy to support both kinds of behaviour and make this configurable.
